### PR TITLE
RFC: Allow installation of system packages (required by some R packages)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 packrat/lib*/
 packrat/src
+.Rproj.user

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,10 @@ RUN rm -rf ./*
 # Make sure the directory for individual app logs exists
 RUN mkdir -p /var/log/shiny-server
 
+# Install apt-get dependecies
+ADD apt-dependencies apt-dependencies
+RUN if [ -s apt-dependencies ]; then apt-get update && apt-get install -y $(cat apt-dependencies) ; fi
+
 # Add Packrat files individually so that next install command
 # can be cached as an image layer separate from application code
 ADD packrat packrat

--- a/apt-dependencies
+++ b/apt-dependencies
@@ -1,0 +1,1 @@
+libgl1-mesa-dev libglu1-mesa-dev

--- a/packrat/packrat.lock
+++ b/packrat/packrat.lock
@@ -1,6 +1,6 @@
 PackratFormat: 1.4
 PackratVersion: 0.4.8.1
-RVersion: 3.3.3
+RVersion: 3.3.2
 Repos: CRAN=https://cran.rstudio.com/
 
 Package: R6
@@ -18,11 +18,28 @@ Source: CRAN
 Version: 0.6.12
 Hash: e53fb8c58673df868183697e39a6a4d6
 
+Package: evaluate
+Source: CRAN
+Version: 0.10
+Hash: c3601a10c987d439e0c63ec635234a76
+Requires: stringr
+
+Package: highr
+Source: CRAN
+Version: 0.6
+Hash: aa3d5b7912b5fed4b546ed5cd2a1760b
+
 Package: htmltools
 Source: CRAN
 Version: 0.3.5
 Hash: 3411e0671a44177109dc1a9e4a6bd2a4
 Requires: Rcpp, digest
+
+Package: htmlwidgets
+Source: CRAN
+Version: 0.8
+Hash: e7a3c80acddc2412f96d616949e40bb8
+Requires: htmltools, jsonlite, yaml
 
 Package: httpuv
 Source: CRAN
@@ -35,6 +52,23 @@ Source: CRAN
 Version: 1.3
 Hash: b9cc3c97b7a6cd513e9b516fe881d6c9
 
+Package: knitr
+Source: CRAN
+Version: 1.15.1
+Hash: eed7437e2b614c9e3923b7932b16ac97
+Requires: digest, evaluate, highr, markdown, stringr, yaml
+
+Package: magrittr
+Source: CRAN
+Version: 1.5
+Hash: bdc4d48c3135e8f3b399536ddf160df4
+
+Package: markdown
+Source: CRAN
+Version: 0.7.7
+Hash: fea2343a1119d61b0cc5c0a950d103a3
+Requires: mime
+
 Package: mime
 Source: CRAN
 Version: 0.5
@@ -45,19 +79,41 @@ Source: CRAN
 Version: 0.4.8-1
 Hash: 6ad605ba7b4b476d84be6632393f5765
 
+Package: rgl
+Source: CRAN
+Version: 0.98.1
+Hash: 674c6c04c2217030c22c09be7bcec05d
+Requires: htmltools, htmlwidgets, jsonlite, knitr, magrittr, shiny
+
 Package: shiny
 Source: CRAN
-Version: 1.0.0
-Hash: 315fd5ac8ada4047f81af7c19d5a5974
+Version: 1.0.1
+Hash: 26d81d2e377b54e68a02f3651c39df81
 Requires: R6, digest, htmltools, httpuv, jsonlite, mime, sourcetools,
     xtable
 
 Package: sourcetools
 Source: CRAN
-Version: 0.1.5
-Hash: 04ddeb1c288302222562326a471e2945
+Version: 0.1.6
+Hash: 226d56d7469587da40b0f96180e711b4
+
+Package: stringi
+Source: CRAN
+Version: 1.1.5
+Hash: b6308e49357a0b475f433599e0d8b5eb
+
+Package: stringr
+Source: CRAN
+Version: 1.2.0
+Hash: 25a86d7f410513ebb7c0bc6a5e16bdc3
+Requires: magrittr, stringi
 
 Package: xtable
 Source: CRAN
 Version: 1.8-2
 Hash: 7293235cfcc14cdff1ce7fd1a0212031
+
+Package: yaml
+Source: CRAN
+Version: 2.1.14
+Hash: c81230c3a7d9ba20607ad6b4331173d1

--- a/packrat/packrat.opts
+++ b/packrat/packrat.opts
@@ -3,10 +3,10 @@ use.cache: FALSE
 print.banner.on.startup: auto
 vcs.ignore.lib: TRUE
 vcs.ignore.src: FALSE
-external.packages:
-local.repos:
+external.packages: 
+local.repos: 
 load.external.packages.on.startup: TRUE
-ignored.packages:
+ignored.packages: 
 quiet.package.installation: TRUE
 snapshot.recommended.packages: FALSE
 snapshot.fields:

--- a/rshiny-example.Rproj
+++ b/rshiny-example.Rproj
@@ -1,0 +1,13 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX


### PR DESCRIPTION
For example in this case the shiny app would need to use the `rgl` R package.
Try to install this would fail because of the lack of some Ubuntu packages
(`libgl1-mesa-dev` and `libglu1-mesa-dev` in this case).

The `apt-dependencies` file will contains a list of debian packages separated
by spaces to be installed using `apt-get install ...` when the docker
image is built, before the R packages installed by packrat.