### PR TITLE
Deploy params to optionally disable authentication/set IP restrictions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,20 @@
 
 pipeline {
 
+  parameters {
+    choice(
+      name: 'IP_RESTRICTIONS',
+      description: 'Whether the user needs to access the app from specific IPs',
+      choices: ipRestrictions.choices,
+    )
+
+    booleanParam(
+      name: 'AUTHENTICATION_REQUIRED',
+      description: 'Determine if the app requires authentication.',
+      defaultValue: true
+    )
+  }
+
   agent any
 
   stages {


### PR DESCRIPTION
Apps can be optionally be public (`AUTHENTICATION_REQUIRED` set to false)
and/or require user to be in a specific location (`IP_RESTRICTIONS`).

Parameters will be parsed in the [jenkins-lib's `deploy()`](https://github.com/ministryofjustice/analytics-platform-jenkins-lib/pull/4).

**NOTE**: These should ideally be moved in [jenkins-lib](https://github.com/ministryofjustice/analytics-platform-jenkins-lib)
but I failed to find a way using Jenkins' declarative syntax.