### PR TITLE
Jenkinsfile: Removed `IAM_ROLE_NAME` param

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,12 +14,6 @@ pipeline {
       description: 'Determine if the app requires authentication.',
       defaultValue: true
     )
-
-    string(
-      name: 'AWS_IAM_ROLE',
-      description: 'IAM role that the webapp will assume (optional)',
-      defaultValue: '',
-    )
   }
 
   agent any


### PR DESCRIPTION
This will not be necessary once we merge the jenkins-lib changes as
Jenkins will get the IAM role name directly from the Control Panel API.

**NOTE**: Wait for that to be tested and deployed to [dev/alpha before merging](https://github.com/ministryofjustice/analytics-platform-jenkins-lib/pull/24).


### Ticket
https://trello.com/c/uYUJ0wfT/422-jenkins-job-to-deploy-app-to-get-app-details-iam-role-name-by-request-to-api