### PR TITLE
Build from tagged rshiny

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/shiny@sha256:627a2b7b3b6b1f6e33d37bdba835bbbd854acf70d74010645af71fc3ff6c32b6
+FROM quay.io/mojanalytics/rshiny:v1.0.0
 
 WORKDIR /srv/shiny-server
 


### PR DESCRIPTION
This aligns our version of R Shiny to the same version of base r as runs on the platform