### PR TITLE
Run shiny-server as shiny user instead of as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,10 @@ RUN rm -rf ./*
 # Make sure the directory for individual app logs exists
 RUN mkdir -p /var/log/shiny-server
 
-# Install dependency on xml2
-RUN apt-get update
-RUN apt-get install libxml2-dev --yes
-RUN apt-get install libssl-dev --yes
+# Install dependency on xml2 and cleanup
+RUN apt-get update && \
+apt-get install --yes libxml2-dev libssl-dev && \
+apt-get clean && rm -rf /var/lib/apt/lists/
 
 # Add Packrat files individually so that next install command
 # can be cached as an image layer separate from application code
@@ -23,12 +23,14 @@ RUN R -e "install.packages('packrat'); packrat::restore()"
 # Add shiny app code
 ADD . .
 
-# Shiny runs as 'shiny' user, adjust app directory permissions
-RUN chown -R shiny:shiny .
-
-# APT Cleanup
-RUN apt-get clean && rm -rf /var/lib/apt/lists/
+# Shiny runs as 'shiny' user, adjust permissions
+RUN chown -R shiny:shiny /var/log/shiny-server && \
+chown -R shiny:shiny /usr/local/lib/R/site-library && \
+chown -R shiny:shiny /var/lib/shiny-server && \
+chown -R shiny:shiny .
 
 # Run shiny-server on port 80
-RUN sed -i 's/3838/80/g' /etc/shiny-server/shiny-server.conf
-EXPOSE 80
+RUN sed -i 's/3838/8080/g' /etc/shiny-server/shiny-server.conf
+EXPOSE 8080
+
+USER shiny

--- a/deploy.json
+++ b/deploy.json
@@ -3,5 +3,6 @@
   "disable_authentication": false,
   "allowed_ip_ranges": [
     "DOM1"
-  ]
+  ],
+  "port": 8080
 }


### PR DESCRIPTION
The main changes are:
- shiny-server runs on port `8080` now
- change of ownership of several directories
- shiny-server runs as `shiny` user
- grouped related commands into a single `RUN`/layer

**NOTE**: All these `chown` are a result of `ADD` not adding files as
the selected `USER` otherwise this could have been a bit simpler
(https://github.com/moby/moby/issues/6119)

Part of ticket: https://trello.com/c/x7zhOJ4N/223-run-webapp-as-non-root-not-on-port-80