### PR TITLE
Upgraded AP Shiny Server to fix security vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ADD environment.yml environment.yml
 
 # Install packrat itself then packages from packrat.lock
 RUN conda env update --file environment.yml -n base
-RUN npm i -g ministryofjustice/analytics-platform-shiny-server#v0.0.4
+RUN npm i -g ministryofjustice/analytics-platform-shiny-server#v0.0.5
 
 ## -----------------------------------------------------
 ## Uncomment if still using packrat alongside conda

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ADD environment.yml environment.yml
 
 # Install packrat itself then packages from packrat.lock
 RUN conda env update --file environment.yml -n base
-RUN npm i -g ministryofjustice/analytics-platform-shiny-server#v0.0.3
+RUN npm i -g ministryofjustice/analytics-platform-shiny-server#v0.0.4
 
 ## -----------------------------------------------------
 ## Uncomment if still using packrat alongside conda


### PR DESCRIPTION
#### `websocket-extensions`
The `websocket-extensions` dependency of Analytics Platform Shiny Server
had a security vulnerability which could be used to "exhaust the server's
capacity to process incoming requests" (see link below).

This new version of `analytics-platform-shiny-server` uses a newer version
of `websocket-extensions` which fixes this vulnerability.

See:
- [PR with dependency upgrade]()https://github.com/ministryofjustice/analytics-platform-shiny-server/pull/2
- [Page with more information on this ReDoS vulnerability](https://github.com/advisories/GHSA-g78m-2chm-r7qv)

#### `set-value` and `acorn` vulnerability
This newer version of Analytics Platform Shiny Server also fixes other 2 vulnerabilities in these 2 packages:
- `set-value` vulnerability: https://github.com/advisories/GHSA-4g88-fppr-53pp
- `acorn` vulnerability: https://github.com/advisories/GHSA-6chw-6frg-f759

[See related PR for more details](https://github.com/ministryofjustice/analytics-platform-shiny-server/pull/4).

#### Testing
This change was tested by building and running this docker image/container locally and verifying that the template shiny app is still working as before without any evident problem.

Once [this `analytics-platform-shiny-server` version is released](https://github.com/ministryofjustice/analytics-platform-shiny-server/pull/4) I'm planning to ask a couple of our users to try this new version on some non-critical webapps to see if they can see anything wrong before then rolling this to everyone by merging this PR.

#### Ticket
https://trello.com/c/PLR5Dft2
